### PR TITLE
feature(001) : List todos

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -92,7 +92,8 @@
               "./node_modules/@angular/material/prebuilt-themes/purple-green.css",
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "codeCoverageExclude": ["src/testing/**/*.ts"]
           }
         },
         "lint": {

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# [001] - Init
+# [000] - Init
 
 ## Technical
 
@@ -6,3 +6,18 @@
 - Fix dependencies versions
 - Enforce unit test coverage
 - Add github actions
+
+# [001] - List todos
+
+## Business
+
+- Define the layout for every pages
+- Create page to list all todos
+- Create a fallback page when url is not known (404)
+
+## Technical
+
+- Initialize todolist store
+- Adding aliases to make import readable in tsconfig.json
+- Adding an npm script to allow to run the application outside of virtual machine (port mapping)
+- Adding testing helper to make tests easier (observable, lazyloading)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "quality-check": "ng lint && ng test --no-watch --no-progress --code-coverage --browsers=ChromeHeadlessCI"
+    "quality-check": "ng lint && ng test --no-watch --no-progress --code-coverage --browsers=ChromeHeadlessCI",
+    "start:vm": "ng serve --host 0.0.0.0"
   },
   "private": true,
   "dependencies": {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,12 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { NotFoundComponent } from './shared/pages/not-found/not-found.component';
 
-const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', pathMatch: 'full', redirectTo: '/todos' },
+  { path: 'todos', loadChildren: () => import('./main/todos/todo.module').then((m) => m.TodoModule) },
+  { path: '**', component: NotFoundComponent },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,6 @@
-<router-outlet></router-outlet>
+<mat-toolbar color="primary">
+  <a id="home-page-link" class="toolbar-link" routerLink="">Todos</a>
+</mat-toolbar>
+<main>
+  <router-outlet></router-outlet>
+</main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,19 @@
+:host {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.toolbar-link {
+  text-decoration: none;
+  color: #fff;
+}
+mat-toolbar {
+  flex-shrink: 0;
+}
+main {
+  flex-grow: 1;
+  overflow: auto;
+  router-outlet + ::ng-deep * {
+    min-height: 100%;
+  }
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,18 +1,64 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { SharedModule } from '@shared/shared.module';
+
 import { AppComponent } from './app.component';
+import { routes } from './app-routing.module';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+
+import { TodoModule } from '@todos/todo.module';
+import { fakeRouteLazyLoading } from '@testing/lazyloading';
 
 describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let appComponent: AppComponent;
+  let router: Router;
+  let location: Location;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule.withRoutes(routes)],
       declarations: [AppComponent],
     }).compileComponents();
   });
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    appComponent = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
   });
+
+  it('should have a toolbar and a router-outler', () => {
+    expect(appComponent).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('mat-toolbar')).toBeDefined();
+    expect(fixture.nativeElement.querySelector('router-outlet')).toBeDefined();
+  });
+
+  it('should redirect to /todos and lazyload TodoModule', fakeAsync(() => {
+    fakeRouteLazyLoading(router, routes, 'todos', (module) => {
+      expect(module).toBe(TodoModule);
+    });
+    router.initialNavigation();
+    expect(fixture.nativeElement.querySelector('app-fake-component')).toBeFalsy();
+
+    router.navigateByUrl('/todos');
+    tick();
+    fixture.detectChanges();
+    expect(location.path()).toBe('/todos');
+    expect(fixture.nativeElement.querySelector('app-fake-component')).toBeTruthy();
+  }));
+
+  it('should redirect to 404 page', fakeAsync(() => {
+    router.initialNavigation();
+    expect(fixture.nativeElement.querySelector('app-not-found')).toBeFalsy();
+    router.navigateByUrl('/todosaaa');
+
+    tick();
+    fixture.detectChanges();
+    expect(location.path()).toBe('/todosaaa');
+    expect(fixture.nativeElement.querySelector('app-not-found')).toBeTruthy();
+  }));
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StoreRouterConnectingModule } from '@ngrx/router-store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { environment } from '../environments/environment';
+import { SharedModule } from '@shared/shared.module';
+import { EffectsModule } from '@ngrx/effects';
 
 @NgModule({
   declarations: [AppComponent],
@@ -15,9 +17,11 @@ import { environment } from '../environments/environment';
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
-    StoreModule.forRoot({}, {}),
+    StoreModule.forRoot({}),
     StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: environment.production }),
+    EffectsModule.forRoot([]),
     StoreRouterConnectingModule.forRoot(),
+    SharedModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/main/todos/components/todo-item/todo-item.component.html
+++ b/src/app/main/todos/components/todo-item/todo-item.component.html
@@ -1,0 +1,3 @@
+<ng-container *ngIf="todo">
+  <span class="todo-title">{{ todo.title }}</span>
+</ng-container>

--- a/src/app/main/todos/components/todo-item/todo-item.component.spec.ts
+++ b/src/app/main/todos/components/todo-item/todo-item.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Todo } from '@shared/business/model/Todo';
+
+import { TodoItemComponent } from '@todos/components/todo-item/todo-item.component';
+
+describe('TodoItemComponent', () => {
+  let component: TodoItemComponent;
+  let fixture: ComponentFixture<TodoItemComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TodoItemComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TodoItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(fixture.nativeElement.childElementCount).toBeFalsy();
+  });
+
+  it('should update title when updating given todo', () => {
+    component.todo = new Todo('Laundry');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.todo-title').textContent).toBe('Laundry');
+  });
+});

--- a/src/app/main/todos/components/todo-item/todo-item.component.ts
+++ b/src/app/main/todos/components/todo-item/todo-item.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { Todo } from '@shared/business/model/Todo';
+
+@Component({
+  selector: 'app-todo-item',
+  templateUrl: './todo-item.component.html',
+  styleUrls: ['./todo-item.component.scss'],
+})
+export class TodoItemComponent {
+  @Input()
+  public todo: Todo;
+}

--- a/src/app/main/todos/components/todo-list/todo-list.component.html
+++ b/src/app/main/todos/components/todo-list/todo-list.component.html
@@ -1,0 +1,10 @@
+<mat-card *ngIf="todos?.length">
+  <mat-card-title>Todo list</mat-card-title>
+  <mat-card-content>
+    <mat-list>
+      <mat-list-item *ngFor="let todo of todos">
+        <app-todo-item [attr.id]="'todo_' + todo.id" [todo]="todo"></app-todo-item>
+      </mat-list-item>
+    </mat-list>
+  </mat-card-content>
+</mat-card>

--- a/src/app/main/todos/components/todo-list/todo-list.component.spec.ts
+++ b/src/app/main/todos/components/todo-list/todo-list.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Todo } from '@shared/business/model/Todo';
+import { TodoState } from '@shared/business/model/TodoState';
+
+import { MaterialModule } from '@shared/modules/material/material.module';
+
+import { TodoItemComponent } from '@todos/components/todo-item/todo-item.component';
+import { TodoListComponent } from '@todos/components/todo-list/todo-list.component';
+import { AppState } from '@todos/store/reducer';
+
+describe('TodoListComponent', () => {
+  let component: TodoListComponent;
+  let fixture: ComponentFixture<TodoListComponent>;
+  let store: MockStore<AppState>;
+
+  beforeEach(async () => {
+    const initialState: AppState = { todosFeature: { todoList: [] } };
+
+    await TestBed.configureTestingModule({
+      declarations: [TodoListComponent, TodoItemComponent],
+      imports: [MaterialModule],
+      providers: [provideMockStore({ initialState })],
+    }).compileComponents();
+    store = TestBed.inject(MockStore);
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TodoListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('todos subscription', () => {
+    it('should subscribe to todoList updates', () => {
+      expect(component.todos).toHaveSize(0);
+      expect(fixture.nativeElement.querySelectorAll('app-todo-item')).toHaveSize(0);
+
+      store.setState({ todosFeature: { todoList: [new Todo('Laundry', TodoState.TODO, 1)] } });
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('app-todo-item')).toHaveSize(1);
+      expect(fixture.nativeElement.querySelector('app-todo-item#todo_1')).toBeDefined();
+    });
+  });
+});

--- a/src/app/main/todos/components/todo-list/todo-list.component.ts
+++ b/src/app/main/todos/components/todo-list/todo-list.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { selectTodoList } from '@todos/store/todolist/selector';
+import { Store } from '@ngrx/store';
+import { Todo } from '@shared/business/model/Todo';
+
+@Component({
+  selector: 'app-todo-list',
+  templateUrl: './todo-list.component.html',
+  styleUrls: ['./todo-list.component.scss'],
+})
+export class TodoListComponent implements OnInit {
+  public todos: Todo[];
+
+  constructor(private store: Store) {}
+
+  ngOnInit(): void {
+    this.store.select(selectTodoList).subscribe((todos) => (this.todos = todos));
+  }
+}

--- a/src/app/main/todos/pages/todo-page/todo-page.component.html
+++ b/src/app/main/todos/pages/todo-page/todo-page.component.html
@@ -1,0 +1,1 @@
+<app-todo-list></app-todo-list>

--- a/src/app/main/todos/pages/todo-page/todo-page.component.scss
+++ b/src/app/main/todos/pages/todo-page/todo-page.component.scss
@@ -1,0 +1,16 @@
+:host {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+app-todo-list {
+  width: 100%;
+}
+
+@media (min-width: 501px) {
+  app-todo-list {
+    margin: 1em 0;
+    width: 500px;
+  }
+}

--- a/src/app/main/todos/pages/todo-page/todo-page.component.spec.ts
+++ b/src/app/main/todos/pages/todo-page/todo-page.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
+import { MaterialModule } from '@shared/modules/material/material.module';
+import { TodoItemComponent } from '@todos/components/todo-item/todo-item.component';
+
+import { TodoListComponent } from '@todos/components/todo-list/todo-list.component';
+import { TodoPageComponent } from '@todos/pages/todo-page/todo-page.component';
+import { AppState } from '@todos/store/reducer';
+
+describe('TodoPageComponent', () => {
+  let component: TodoPageComponent;
+  let fixture: ComponentFixture<TodoPageComponent>;
+
+  beforeEach(async () => {
+    const initialState: AppState = { todosFeature: { todoList: [] } };
+
+    await TestBed.configureTestingModule({
+      declarations: [TodoListComponent, TodoItemComponent],
+      imports: [MaterialModule],
+      providers: [provideMockStore({ initialState })],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TodoPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/todos/pages/todo-page/todo-page.component.ts
+++ b/src/app/main/todos/pages/todo-page/todo-page.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-todo-page',
+  templateUrl: './todo-page.component.html',
+  styleUrls: ['./todo-page.component.scss'],
+})
+export class TodoPageComponent {}

--- a/src/app/main/todos/resolvers/todolist.resolver.spec.ts
+++ b/src/app/main/todos/resolvers/todolist.resolver.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+
+import { AppState } from '@todos/store/reducer';
+import { TodolistResolver } from '@todos/resolvers/todolist.resolver';
+import { Todo } from '@shared/business/model/Todo';
+
+describe('TodolistResolver', () => {
+  let resolver: TodolistResolver;
+  let store: MockStore<AppState>;
+
+  beforeEach(() => {
+    const initialState: AppState = { todosFeature: { todoList: [] } };
+
+    TestBed.configureTestingModule({
+      providers: [TodolistResolver, provideMockStore({ initialState })],
+    });
+    resolver = TestBed.inject(TodolistResolver);
+    store = TestBed.inject(MockStore);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+
+  describe('resolve', () => {
+    it('should return true when store todoList is set', () => {
+      const todoList = [new Todo('Laundry')];
+
+      store.setState({ todosFeature: { todoList } });
+      resolver.resolve().subscribe((value) => {
+        expect(value).toBeTrue();
+      });
+    });
+  });
+});

--- a/src/app/main/todos/resolvers/todolist.resolver.ts
+++ b/src/app/main/todos/resolvers/todolist.resolver.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+import { startLoading } from '../store/todolist/actions';
+import { selectTodoList } from '../store/todolist/selector';
+
+@Injectable()
+export class TodolistResolver implements Resolve<boolean> {
+  constructor(private store: Store) {}
+
+  resolve(): Observable<boolean> {
+    this.store.dispatch(startLoading());
+
+    return this.store.select(selectTodoList).pipe(
+      take(1),
+      map(() => true)
+    );
+  }
+}

--- a/src/app/main/todos/services/todo-http.service.spec.ts
+++ b/src/app/main/todos/services/todo-http.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { TodoHttpService } from './todo-http.service';
+
+describe('TodoHttpService', () => {
+  let todoHttp: TodoHttpService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [TodoHttpService],
+    });
+    todoHttp = TestBed.inject(TodoHttpService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should be created', () => {
+    expect(todoHttp).toBeTruthy();
+  });
+
+  describe('getTodos', () => {
+    it('should call "assets/mocks/todos.json"', () => {
+      todoHttp.getTodos().subscribe((todos) => {
+        expect(todos).toHaveSize(0);
+      });
+
+      const testRequest = httpTestingController.expectOne('assets/mocks/todos.json');
+      expect(testRequest.request.method).toBe('GET');
+      testRequest.flush([]);
+    });
+  });
+});

--- a/src/app/main/todos/services/todo-http.service.ts
+++ b/src/app/main/todos/services/todo-http.service.ts
@@ -1,0 +1,13 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Todo } from '@shared/business/model/Todo';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class TodoHttpService {
+  constructor(private http: HttpClient) {}
+
+  getTodos(): Observable<Todo[]> {
+    return this.http.get<Todo[]>('assets/mocks/todos.json');
+  }
+}

--- a/src/app/main/todos/store/reducer.ts
+++ b/src/app/main/todos/store/reducer.ts
@@ -1,0 +1,17 @@
+import { ActionReducerMap } from '@ngrx/store';
+
+import * as fromTodoList from './todolist/reducer';
+
+export const todosFeatureKey = 'todosFeature';
+
+export interface TodosFeatureState {
+  todoList: fromTodoList.State;
+}
+
+export const todosFeatureReducer: ActionReducerMap<TodosFeatureState> = {
+  todoList: fromTodoList.todoListReducer,
+};
+
+export interface AppState {
+  [todosFeatureKey]: TodosFeatureState;
+}

--- a/src/app/main/todos/store/todolist/actions.ts
+++ b/src/app/main/todos/store/todolist/actions.ts
@@ -1,0 +1,6 @@
+import { createAction, props } from '@ngrx/store';
+import { Todo } from '@shared/business/model/Todo';
+
+export const startLoading = createAction('[TodoList] Start loading');
+export const dataLoaded = createAction('[TodoList] Data loaded', props<{ todos: Todo[] }>());
+export const loadingFailed = createAction('[TodoList] Loading failed');

--- a/src/app/main/todos/store/todolist/effects.spec.ts
+++ b/src/app/main/todos/store/todolist/effects.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Observable } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+
+import { Action } from '@ngrx/store';
+import { provideMockActions } from '@ngrx/effects/testing';
+
+import { TodoHttpService } from '@todos/services/todo-http.service';
+import { TodoListEffects } from '@todos/store/todolist/effects';
+import { dataLoaded, loadingFailed, startLoading } from '@todos/store/todolist/actions';
+import { Todo } from '@shared/business/model/Todo';
+import { TodoState } from '@shared/business/model/TodoState';
+import { getTestScheduler } from '@testing/observable';
+
+describe('TodoListEffects', () => {
+  let todoListEffects: TodoListEffects;
+
+  let actions$: Observable<Action>;
+  let todoHttpService: jasmine.SpyObj<TodoHttpService>;
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TodoListEffects,
+        provideMockActions(() => actions$),
+        { provide: TodoHttpService, useValue: jasmine.createSpyObj('TodoHttpService', ['getTodos']) },
+      ],
+    });
+
+    testScheduler = getTestScheduler();
+    todoListEffects = TestBed.inject(TodoListEffects);
+    todoHttpService = TestBed.inject(TodoHttpService) as jasmine.SpyObj<TodoHttpService>;
+  });
+
+  it('should be created', () => {
+    expect(todoListEffects).toBeTruthy();
+  });
+
+  describe('setTodoList$', () => {
+    it('Should map startLoading to dataLoadedAction', () => {
+      const todos = [
+        new Todo('Laundry', TodoState.TODO, 1),
+        new Todo('Feed the cat', TodoState.TODO, 2),
+        new Todo('Do the dishes', TodoState.TODO, 3),
+      ];
+      const inputAction = startLoading();
+      const outputAction = dataLoaded({ todos });
+
+      testScheduler.run(({ cold, hot, expectObservable }) => {
+        actions$ = hot('-a', { a: inputAction });
+        const result$ = cold('-b|', { b: todos });
+
+        todoHttpService.getTodos.and.returnValue(result$);
+        expectObservable(todoListEffects.setTodoList$).toBe('--b', { b: outputAction });
+      });
+    });
+
+    it('Should map startLoading to loadingFailed', () => {
+      const inputAction = startLoading();
+      const outputAction = loadingFailed();
+
+      testScheduler.run(({ cold, hot, expectObservable }) => {
+        actions$ = hot('-a', { a: inputAction });
+        const result$ = cold<Todo[]>('-#|');
+
+        todoHttpService.getTodos.and.returnValue(result$);
+        expectObservable(todoListEffects.setTodoList$).toBe('--b', { b: outputAction });
+      });
+    });
+  });
+});

--- a/src/app/main/todos/store/todolist/effects.ts
+++ b/src/app/main/todos/store/todolist/effects.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { TodoHttpService } from '@todos/services/todo-http.service';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, map, mergeMap } from 'rxjs/operators';
+import { dataLoaded, loadingFailed, startLoading } from './actions';
+
+@Injectable()
+export class TodoListEffects {
+  setTodoList$ = createEffect(() =>
+    this.action$.pipe(
+      ofType(startLoading),
+      mergeMap(() =>
+        this.todoService.getTodos().pipe(
+          map((todos) => dataLoaded({ todos })),
+          catchError(() => of(loadingFailed()))
+        )
+      )
+    )
+  );
+
+  constructor(private action$: Actions, private todoService: TodoHttpService) {}
+}

--- a/src/app/main/todos/store/todolist/reducer.spec.ts
+++ b/src/app/main/todos/store/todolist/reducer.spec.ts
@@ -1,0 +1,44 @@
+import { Action } from '@ngrx/store';
+import { Todo } from '@shared/business/model/Todo';
+import { dataLoaded, loadingFailed, startLoading } from './actions';
+import { State, todoListReducer } from './reducer';
+
+describe('todoListReducer', () => {
+  let state: State;
+  const dispatch = (action: Action) => {
+    state = todoListReducer(state, action);
+  };
+
+  beforeEach(() => {
+    state = [];
+  });
+
+  describe('startLoading', () => {
+    it('should not edit the state', () => {
+      const oldState = state;
+
+      dispatch(startLoading());
+      expect(oldState).toBe(state);
+    });
+  });
+
+  describe('dataLoaded', () => {
+    it('should not edit the state', () => {
+      const oldState = state;
+      const todos = [new Todo()];
+
+      dispatch(dataLoaded({ todos }));
+      expect(oldState).not.toBe(state);
+      expect(state).toHaveSize(1);
+    });
+  });
+
+  describe('loadingFailed', () => {
+    it('should not edit the state', () => {
+      const oldState = state;
+
+      dispatch(loadingFailed());
+      expect(oldState).toBe(state);
+    });
+  });
+});

--- a/src/app/main/todos/store/todolist/reducer.ts
+++ b/src/app/main/todos/store/todolist/reducer.ts
@@ -1,0 +1,14 @@
+import { createReducer, on } from '@ngrx/store';
+import { Todo } from '@shared/business/model/Todo';
+import { startLoading, dataLoaded, loadingFailed } from './actions';
+
+export type State = Todo[];
+
+const initialState: State = [];
+
+export const todoListReducer = createReducer(
+  initialState,
+  on(startLoading, (state) => state),
+  on(dataLoaded, (state, { todos }) => todos),
+  on(loadingFailed, (state) => state)
+);

--- a/src/app/main/todos/store/todolist/selector.ts
+++ b/src/app/main/todos/store/todolist/selector.ts
@@ -1,0 +1,6 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import * as fromTodosFeature from '../reducer';
+
+const selectState = createFeatureSelector<fromTodosFeature.TodosFeatureState>(fromTodosFeature.todosFeatureKey);
+
+export const selectTodoList = createSelector(selectState, (state) => [...state.todoList]);

--- a/src/app/main/todos/todo-routing.module.ts
+++ b/src/app/main/todos/todo-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { TodoPageComponent } from './pages/todo-page/todo-page.component';
+import { TodolistResolver } from './resolvers/todolist.resolver';
+
+const routes: Routes = [{ path: '', component: TodoPageComponent, resolve: { todos: TodolistResolver } }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class TodoRoutingModule {}

--- a/src/app/main/todos/todo.module.ts
+++ b/src/app/main/todos/todo.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { TodoRoutingModule } from './todo-routing.module';
+import { TodoPageComponent } from './pages/todo-page/todo-page.component';
+import { TodoListComponent } from './components/todo-list/todo-list.component';
+import { SharedModule } from '@shared/shared.module';
+import { TodoItemComponent } from './components/todo-item/todo-item.component';
+import { StoreModule } from '@ngrx/store';
+import { todosFeatureKey, todosFeatureReducer } from './store/reducer';
+import { EffectsModule } from '@ngrx/effects';
+import { TodoListEffects } from './store/todolist/effects';
+import { TodolistResolver } from './resolvers/todolist.resolver';
+import { TodoHttpService } from './services/todo-http.service';
+
+@NgModule({
+  declarations: [TodoPageComponent, TodoListComponent, TodoItemComponent],
+  imports: [
+    CommonModule,
+    TodoRoutingModule,
+    SharedModule,
+    StoreModule.forFeature(todosFeatureKey, todosFeatureReducer),
+    EffectsModule.forFeature([TodoListEffects]),
+  ],
+  providers: [TodoHttpService, TodolistResolver],
+})
+export class TodoModule {}

--- a/src/app/shared/business/model/Todo/Todo.spec.ts
+++ b/src/app/shared/business/model/Todo/Todo.spec.ts
@@ -1,0 +1,39 @@
+import { TodoState } from '../TodoState';
+import { Todo } from './index';
+
+describe('Test class Todo', () => {
+  it('Should have empty title and his state should be "TODO"', () => {
+    const todo = new Todo();
+    expect(todo.id).toBeUndefined();
+    expect(todo.title).toBe('');
+    expect(todo.state).toBe('TODO');
+  });
+
+  it('Should have the given state and its title should be empty', () => {
+    const todo = new Todo(undefined, TodoState.DONE);
+    expect(todo.id).toBeUndefined();
+    expect(todo.title).toBe('');
+    expect(todo.state).toBe('DONE');
+  });
+
+  it('Should have the given title and his state should be "TODO"', () => {
+    const todo = new Todo('Laundry');
+    expect(todo.id).toBeUndefined();
+    expect(todo.title).toBe('Laundry');
+    expect(todo.state).toBe('TODO');
+  });
+
+  it('Should have the given title and state', () => {
+    const todo = new Todo('Laundry', TodoState.DONE);
+    expect(todo.id).toBeUndefined();
+    expect(todo.title).toBe('Laundry');
+    expect(todo.state).toBe('DONE');
+  });
+
+  it('Should have the given title, state and id', () => {
+    const todo = new Todo('Laundry', TodoState.DONE, 1);
+    expect(todo.id).toBe(1);
+    expect(todo.title).toBe('Laundry');
+    expect(todo.state).toBe('DONE');
+  });
+});

--- a/src/app/shared/business/model/Todo/index.ts
+++ b/src/app/shared/business/model/Todo/index.ts
@@ -1,0 +1,5 @@
+import { TodoState } from '../TodoState';
+
+export class Todo {
+  constructor(public title = '', public state = TodoState.TODO, public id?: number) {}
+}

--- a/src/app/shared/business/model/TodoState/index.ts
+++ b/src/app/shared/business/model/TodoState/index.ts
@@ -1,0 +1,4 @@
+export enum TodoState {
+  DONE = 'DONE',
+  TODO = 'TODO',
+}

--- a/src/app/shared/modules/material/material.module.ts
+++ b/src/app/shared/modules/material/material.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+
+import { MatListModule } from '@angular/material/list';
+import { MatCardModule } from '@angular/material/card';
+import { MatToolbarModule } from '@angular/material/toolbar';
+
+@NgModule({
+  declarations: [],
+  imports: [MatCardModule, MatListModule, MatToolbarModule],
+  exports: [MatCardModule, MatListModule, MatToolbarModule],
+})
+export class MaterialModule {}

--- a/src/app/shared/pages/not-found/not-found.component.html
+++ b/src/app/shared/pages/not-found/not-found.component.html
@@ -1,0 +1,1 @@
+<mat-card>404 - Page not found</mat-card>

--- a/src/app/shared/pages/not-found/not-found.component.scss
+++ b/src/app/shared/pages/not-found/not-found.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/app/shared/pages/not-found/not-found.component.spec.ts
+++ b/src/app/shared/pages/not-found/not-found.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '@shared/modules/material/material.module';
+
+import { NotFoundComponent } from './not-found.component';
+
+describe('NotFoundComponent', () => {
+  let component: NotFoundComponent;
+  let fixture: ComponentFixture<NotFoundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotFoundComponent],
+      imports: [MaterialModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/pages/not-found/not-found.component.ts
+++ b/src/app/shared/pages/not-found/not-found.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-not-found',
+  templateUrl: './not-found.component.html',
+  styleUrls: ['./not-found.component.scss'],
+})
+export class NotFoundComponent {}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { MaterialModule } from './modules/material/material.module';
+import { NotFoundComponent } from './pages/not-found/not-found.component';
+
+@NgModule({
+  declarations: [NotFoundComponent],
+  imports: [CommonModule, HttpClientModule, MaterialModule],
+  exports: [NotFoundComponent, HttpClientModule, MaterialModule],
+})
+export class SharedModule {}

--- a/src/assets/mocks/todos.json
+++ b/src/assets/mocks/todos.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": 1,
+    "title": "delectus aut autem",
+    "state": "TODO"
+  },
+  {
+    "id": 2,
+    "title": "quis ut nam facilis et officia qui",
+    "state": "TODO"
+  },
+  {
+    "id": 3,
+    "title": "fugiat veniam minus",
+    "state": "TODO"
+  },
+  {
+    "id": 4,
+    "title": "et porro tempora",
+    "state": "DONE"
+  },
+  {
+    "id": 5,
+    "title": "laboriosam mollitia et enim quasi adipisci quia provident illum",
+    "state": "TODO"
+  },
+  {
+    "id": 6,
+    "title": "qui ullam ratione quibusdam voluptatem quia omnis",
+    "state": "TODO"
+  },
+  {
+    "id": 7,
+    "title": "illo expedita consequatur quia in",
+    "state": "TODO"
+  },
+  {
+    "id": 8,
+    "title": "quo adipisci enim quam ut ab",
+    "state": "DONE"
+  },
+  {
+    "id": 9,
+    "title": "molestiae perspiciatis ipsa",
+    "state": "TODO"
+  },
+  {
+    "id": 10,
+    "title": "illo est ratione doloremque quia maiores aut",
+    "state": "DONE"
+  }
+]

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,4 +9,5 @@ body {
 body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;
+  background-color: #303030;
 }

--- a/src/testing/lazyloading.ts
+++ b/src/testing/lazyloading.ts
@@ -1,0 +1,38 @@
+import { Component, NgModule } from '@angular/core';
+import { LoadChildrenCallback, Router, RouterModule, Routes, Route } from '@angular/router';
+
+@Component({ template: `Fake Component`, selector: 'app-fake-component' })
+class FakeTodoComponent {}
+
+@NgModule({
+  declarations: [FakeTodoComponent],
+  imports: [RouterModule.forChild([{ path: '', component: FakeTodoComponent }])],
+})
+class FakeTodosModule {}
+
+export const fakeRouteLazyLoading = (
+  router: Router,
+  initialRoutes: Routes,
+  path: string,
+  expectation: (module: any) => void
+) => {
+  const correspondingRoute = initialRoutes.find((initialRoute) => initialRoute.path === path);
+
+  if (correspondingRoute) {
+    const newRoute: Route = {
+      ...correspondingRoute,
+      loadChildren: async () => {
+        const module = await (correspondingRoute.loadChildren as LoadChildrenCallback)();
+
+        expectation(module);
+        return Promise.resolve(FakeTodosModule);
+      },
+    };
+
+    const newRoutes: Routes = [...initialRoutes];
+    newRoutes.splice(initialRoutes.indexOf(correspondingRoute), 1, newRoute);
+    router.resetConfig(newRoutes);
+    return newRoutes;
+  }
+  return initialRoutes;
+};

--- a/src/testing/observable.ts
+++ b/src/testing/observable.ts
@@ -1,0 +1,6 @@
+import { TestScheduler } from 'rxjs/testing';
+
+export const getTestScheduler = () =>
+  new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,11 +5,6 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,11 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",
+    "paths": {
+      "@shared/*": ["src/app/shared/*"],
+      "@todos/*": ["src/app/main/todos/*"],
+      "@testing/*": ["src/testing/*"]
+    },
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -16,7 +21,8 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "es2020",
-    "lib": ["es2018", "dom"]
+    "lib": ["es2018", "dom"],
+    "strictNullChecks": false
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,16 +3,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
+    "types": ["jasmine"]
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,111 +1,111 @@
 {
-    "extends": "tslint:recommended",
-    "rulesDirectory": ["codelyzer"],
-    "rules": {
-        "align": {
-            "options": ["parameters", "statements"]
+  "extends": "tslint:recommended",
+  "rulesDirectory": ["codelyzer"],
+  "rules": {
+    "align": {
+      "options": ["parameters", "statements"]
+    },
+    "array-type": false,
+    "arrow-return-shorthand": true,
+    "curly": true,
+    "deprecation": {
+      "severity": "warning"
+    },
+    "eofline": true,
+    "import-blacklist": [true, "rxjs/Rx"],
+    "import-spacing": true,
+    "indent": {
+      "options": ["spaces"]
+    },
+    "max-classes-per-file": false,
+    "max-line-length": [true, 150],
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-field",
+          "instance-field",
+          "static-method",
+          "instance-method"
+        ]
+      }
+    ],
+    "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
+    "no-empty": false,
+    "no-inferrable-types": [true, "ignore-params"],
+    "no-non-null-assertion": true,
+    "no-redundant-jsdoc": true,
+    "no-switch-case-fall-through": true,
+    "no-var-requires": false,
+    "object-literal-key-quotes": [true, "as-needed"],
+    "quotemark": [true, "single"],
+    "semicolon": {
+      "options": ["always"]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
+      }
+    },
+    "typedef": [true, "call-signature"],
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
         },
-        "array-type": false,
-        "arrow-return-shorthand": true,
-        "curly": true,
-        "deprecation": {
-            "severity": "warning"
-        },
-        "eofline": true,
-        "import-blacklist": [true, "rxjs/Rx"],
-        "import-spacing": true,
-        "indent": {
-            "options": ["spaces"]
-        },
-        "max-classes-per-file": false,
-        "max-line-length": [true, 150],
-        "member-ordering": [
-            true,
-            {
-                "order": [
-                    "static-field",
-                    "instance-field",
-                    "static-method",
-                    "instance-method"
-                ]
-            }
-        ],
-        "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-        "no-empty": false,
-        "no-inferrable-types": [true, "ignore-params"],
-        "no-non-null-assertion": true,
-        "no-redundant-jsdoc": true,
-        "no-switch-case-fall-through": true,
-        "no-var-requires": false,
-        "object-literal-key-quotes": [true, "as-needed"],
-        "quotemark": [true, "single"],
-        "semicolon": {
-            "options": ["always"]
-        },
-        "space-before-function-paren": {
-            "options": {
-                "anonymous": "never",
-                "asyncArrow": "always",
-                "constructor": "never",
-                "method": "never",
-                "named": "never"
-            }
-        },
-        "typedef": [true, "call-signature"],
-        "typedef-whitespace": {
-            "options": [
-                {
-                    "call-signature": "nospace",
-                    "index-signature": "nospace",
-                    "parameter": "nospace",
-                    "property-declaration": "nospace",
-                    "variable-declaration": "nospace"
-                },
-                {
-                    "call-signature": "onespace",
-                    "index-signature": "onespace",
-                    "parameter": "onespace",
-                    "property-declaration": "onespace",
-                    "variable-declaration": "onespace"
-                }
-            ]
-        },
-        "variable-name": {
-            "options": ["ban-keywords", "check-format", "allow-pascal-case"]
-        },
-        "whitespace": {
-            "options": [
-                "check-branch",
-                "check-decl",
-                "check-operator",
-                "check-separator",
-                "check-type",
-                "check-typecast"
-            ]
-        },
-        "component-class-suffix": true,
-        "contextual-lifecycle": true,
-        "directive-class-suffix": true,
-        "no-conflicting-lifecycle": true,
-        "no-host-metadata-property": true,
-        "no-input-rename": true,
-        "no-inputs-metadata-property": true,
-        "no-output-native": true,
-        "no-output-on-prefix": true,
-        "no-output-rename": true,
-        "no-outputs-metadata-property": true,
-        "template-banana-in-box": true,
-        "template-no-negated-async": true,
-        "use-lifecycle-interface": true,
-        "use-pipe-transform-interface": true,
-        "directive-selector": [true, "attribute", "app", "camelCase"],
-        "component-selector": [true, "element", "app", "kebab-case"],
-        "arrow-parens": false,
-        "interface-name": false,
-        "member-access": false,
-        "no-consecutive-blank-lines": false,
-        "object-literal-sort-keys": false,
-        "ordered-imports": false,
-        "trailing-comma": false
-    }
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+    "variable-name": {
+      "options": ["ban-keywords", "check-format", "allow-pascal-case"]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    },
+    "component-class-suffix": true,
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
+    "no-host-metadata-property": true,
+    "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
+    "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
+    "use-lifecycle-interface": true,
+    "use-pipe-transform-interface": true,
+    "directive-selector": [true, "attribute", "app", "camelCase"],
+    "component-selector": [true, "element", "app", "kebab-case"],
+    "arrow-parens": false,
+    "interface-name": false,
+    "member-access": false,
+    "no-consecutive-blank-lines": false,
+    "object-literal-sort-keys": false,
+    "ordered-imports": false,
+    "trailing-comma": false
+  }
 }


### PR DESCRIPTION
	Business changes :
	- Define the layout for every pages
	- Create page to list all todos
	- Create a fallback page when url is not known (404)

	Technical changes :
	- Initialize todolist store
	- Adding aliases to make import readable in tsconfig.json
	- Adding an npm script to allow to run the application outside of virtual machine (port mapping)
	- Adding testing helper to make tests easier (observable, lazyloading)